### PR TITLE
Refactor into functions and patterns only

### DIFF
--- a/test/plug_basic_auth_test.exs
+++ b/test/plug_basic_auth_test.exs
@@ -21,7 +21,7 @@ defmodule PlugBasicAuthTest do
     PrivatePlug.call(conn, [])
   end
 
-  test "prompts for username on password" do
+  test "prompts for username and password" do
     conn = conn(:get, "/") |> call
     assert conn.status == 401
     assert get_resp_header(conn, "Www-Authenticate") == ["Basic realm=\"Private Area\""]


### PR DESCRIPTION
I just watched Dave's ElixirConf talk and it prompted me to think about refactoring this code after I had reviewed it a few days ago. No need to accept this, but I thought it did clean up the call path nicely and would make the DIGEST auth easier to implement.
