### PR TITLE
Bump plug version

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -20,7 +20,7 @@ defmodule PlugBasicAuth.Mixfile do
 
   defp deps do
     [{:cowboy, "~> 1.0.0"},
-     {:plug, "~> 0.10.0"},
+     {:plug, "~> 0.12.2"},
      {:ex_doc, github: "elixir-lang/ex_doc", only: [:docs]}]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{"cowboy": {:hex, :cowboy, "1.0.0"},
   "cowlib": {:hex, :cowlib, "1.0.1"},
   "ex_doc": {:git, "git://github.com/elixir-lang/ex_doc.git", "ce0fa1202f93642fdf84531257194eb73538d188", []},
-  "plug": {:hex, :plug, "0.10.0"},
+  "plug": {:hex, :plug, "0.12.2"},
   "ranch": {:hex, :ranch, "1.0.0"}}


### PR DESCRIPTION
[Plug](http://hexdocs.pm/plug) version is a few out of date. This patch bumps the version to anything equivalent to `0.12.2`.