### PR TITLE
Allow creds to be stored outside of code

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,35 @@ defmodule TopSecret do
 end
 ```
 
+If you wish to pull the username and password from outside your code, ie, S3, you can pass a method to PlugBasicAuth that gets the values.
+
+```elixir
+# Create a method to return our username/pw tuple.  In the real world,
+# this would hit S3 or some other location that contains your credentials
+  defmodule Test do
+    def user_and_pw do
+      {"Snorky", "Capone"}
+    end
+  end
+
+  defmodule TopSecret do
+    import Plug.Conn
+    use Plug.Router
+    
+    plug PlugBasicAuth, setup: &Test.user_and_pw/0
+    plug :match
+    plug :dispatch
+    
+    get '/speakeasy' do
+      conn
+      |> put_resp_content_type("text/plain")
+      |> send_resp(200, "Welcome to the party.")
+    end
+  end
+```
+
+
+
 ## Todo
 
 * Enable adding authentication on a per route basis, instead of per router

--- a/lib/plug_basic_auth.ex
+++ b/lib/plug_basic_auth.ex
@@ -93,8 +93,11 @@ defmodule PlugBasicAuth do
   end
 
   defp handle_auth_setup_from_method(method, _username, _password) do
-    {username, password} = method.()
-    handle_auth_setup_from_method(nil, username, password)
+    case method.() do
+      {username, password} ->
+      handle_auth_setup_from_method(nil, username, password)
+      _ -> "invalid_creds"
+    end
   end
 
   defp get_auth_header(conn) do

--- a/lib/plug_basic_auth.ex
+++ b/lib/plug_basic_auth.ex
@@ -69,9 +69,8 @@ defmodule PlugBasicAuth do
   def init(opts) do
     username = Keyword.get(opts, :username)
     password = Keyword.get(opts, :password)
-    username_password = username <> ":" <> password
     Keyword.get(opts, :setup)
-    |> handle_auth_setup_from_method(username_password)
+    |> handle_auth_setup_from_method(username, password)
   end
 
   def call(conn, server_creds) do
@@ -81,11 +80,19 @@ defmodule PlugBasicAuth do
     |> check_creds(server_creds)
   end
 
-  defp handle_auth_setup_from_method(nil, username_password) do
-    username_password
+  defp handle_auth_setup_from_method(nil, nil, _password) do
+    "invalid_creds"
   end
 
-  defp handle_auth_setup_from_method(method, _username_password) do
+  defp handle_auth_setup_from_method(nil, _username, nil) do
+    "invalid_creds"
+  end
+
+  defp handle_auth_setup_from_method(nil, username, password) do
+    username <> ":" <> password
+  end
+
+  defp handle_auth_setup_from_method(method, _username, _password) do
     {username, password} = method.()
     username <> ":" <> password
   end

--- a/lib/plug_basic_auth.ex
+++ b/lib/plug_basic_auth.ex
@@ -94,7 +94,7 @@ defmodule PlugBasicAuth do
 
   defp handle_auth_setup_from_method(method, _username, _password) do
     {username, password} = method.()
-    username <> ":" <> password
+    handle_auth_setup_from_method(nil, username, password)
   end
 
   defp get_auth_header(conn) do

--- a/lib/plug_basic_auth.ex
+++ b/lib/plug_basic_auth.ex
@@ -30,6 +30,35 @@ defmodule PlugBasicAuth do
           |> send_resp(200, "Welcome to the party.")
         end
       end
+
+  Alternatively, a method can be passed in that returns a tuple of username
+  and password.  This allows for creation of a method to fetch the credentials
+  so that the credentials are not stored in code.
+
+  ## Example with creds from method
+
+    # Create a method to return our username/pw tuple.  In the real world,
+    # this would hit S3 or some other location that contains your credentials
+    defmodule Test do
+      def user_and_pw do
+        {"Snorky", "Capone"}
+      end
+    end
+
+    defmodule TopSecret do
+      import Plug.Conn
+      use Plug.Router
+
+      plug PlugBasicAuth, setup: &Test.user_and_pw/0 
+      plug :match
+      plug :dispatch
+
+      get '/speakeasy' do
+        conn
+        |> put_resp_content_type("text/plain")
+        |> send_resp(200, "Welcome to the party.")
+      end
+    end
   """
 
   import Plug.Conn, only: [get_req_header:  2,
@@ -38,9 +67,11 @@ defmodule PlugBasicAuth do
                            halt:            1]
 
   def init(opts) do
-    username = Keyword.fetch!(opts, :username)
-    password = Keyword.fetch!(opts, :password)
-    username <> ":" <> password
+    username = Keyword.get(opts, :username)
+    password = Keyword.get(opts, :password)
+    username_password = username <> ":" <> password
+    Keyword.get(opts, :setup)
+    |> handle_auth_setup_from_method(username_password)
   end
 
   def call(conn, server_creds) do
@@ -48,6 +79,15 @@ defmodule PlugBasicAuth do
     |> get_auth_header
     |> parse_auth
     |> check_creds(server_creds)
+  end
+
+  defp handle_auth_setup_from_method(nil, username_password) do
+    username_password
+  end
+
+  defp handle_auth_setup_from_method(method, _username_password) do
+    {username, password} = method.()
+    username <> ":" <> password
   end
 
   defp get_auth_header(conn) do

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule PlugBasicAuth.Mixfile do
 
   def project do
     [app: :plug_basic_auth,
-     version: "0.3.2",
+     version: "0.3.3",
      elixir: "~> 1.0.0",
      deps: deps,
      package: package,


### PR DESCRIPTION
Few adjustments so that a method can be passed to the plug that sets the username and password.  This allows the option to pull these creds from anywhere so that they are not hard coded into the source code.