### PR TITLE
Relax Elixir version requirement

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule PlugBasicAuth.Mixfile do
   def project do
     [app: :plug_basic_auth,
      version: "0.3.3",
-     elixir: "~> 1.0.0",
+     elixir: "~> 1.0",
      deps: deps,
      package: package,
      name: "Plug Basic Auth",


### PR DESCRIPTION
When using `plug_basic_auth` on any elixir version greater than `1.0.x` (e.g. current HEAD), I get this warning when compiling:

    warning: the dependency plug_basic_auth requires Elixir "~> 1.0.0" but you are running on v1.1.0-dev

Since Elixir follows SemVer it should be safe to allow this plug to run on any `1.x` version of Elixir.